### PR TITLE
`start_neuron.sh` yes/no prompt is now skipped if variable is set + Added `FLASK_SERVER` miner-specific variables and the related input parameter

### DIFF
--- a/scripts/start_neuron.sh
+++ b/scripts/start_neuron.sh
@@ -25,6 +25,7 @@ LOGGING_LEVEL=""
 # Miner-specific variables
 AXON_PORT=""
 VALIDATOR_MIN_STAKE=""
+FLASK_SERVER=""
 
 # Function to prompt for user input if not provided as an argument
 prompt_for_input() {
@@ -41,6 +42,13 @@ prompt_for_input() {
 prompt_yes_no() {
     local prompt="$1"
     local var_name="$2"
+    local current_value="${!var_name}"
+
+    # Skip prompt if var_name is already set to 'true' or 'false'
+    if [[ "$current_value" == "true" || "$current_value" == "false" ]]; then
+      return 0
+    fi
+
     while true; do
         read -p "$prompt [y/n]: " yn
         case $yn in
@@ -62,6 +70,7 @@ while [[ $# -gt 0 ]]; do
         --axon.port) AXON_PORT="$2"; shift 2 ;;
         --validator_min_stake) VALIDATOR_MIN_STAKE="$2"; shift 2 ;;
         --disable_auto_update) DISABLE_AUTO_UPDATE="$2"; shift 2 ;;
+        --start_flask_server) FLASK_SERVER="$2"; shift 2 ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
 done


### PR DESCRIPTION
In this pull request I added: 

1. A check in the `prompt_yes_no()` function of the `start_neuron.sh` script to skip the prompt if the variable is already set to `true` or `false`
    * This allows users to fully automate the usage of the script by passing `--disable_auto_update` and/or `--start_flask_server`
2. The `FLASK_SERVER` miner-specific variable to go with the new `--start_flask_server` input parameter

I tested everything by using it to setup a validator and this testing script:

```
DISABLE_AUTO_UPDATE=""
FLASK_SERVER=""

prompt_yes_no() {
    local prompt="$1"
    local var_name="$2"
    local current_value="${!var_name}"

    # Check if var_name is already set to 'true' or 'false'
    if [[ "$current_value" == "true" || "$current_value" == "false" ]]; then
      echo "$var_name is already set to $current_value, skipping prompt."
      return 0
    fi

    while true; do
        read -p "$prompt [y/n]: " yn
        case $yn in
            [Yy]* ) eval $var_name="true"; break;;
            [Nn]* ) eval $var_name="false"; break;;
            * ) echo "Please answer yes or no.";;
        esac
    done
}

while [[ $# -gt 0 ]]; do
    case $1 in
        --disable_auto_update) DISABLE_AUTO_UPDATE="$2"; shift 2 ;;
        --start_flask_server) FLASK_SERVER="$2"; shift 2 ;;
        *) echo "Unknown parameter passed: $1"; exit 1 ;;
    esac
done

# Prompt for disabling auto-update if not provided
prompt_yes_no "Do you want to disable auto-update? Warning: this will apply to all running neurons" "DISABLE_AUTO_UPDATE"

# Prompt for starting Flask server
prompt_yes_no "Would you like to start flask server for connecting to bettensor.com?" "FLASK_SERVER"
```

Output:
![image](https://github.com/user-attachments/assets/12122c00-b456-4415-a337-9b682029f090)