### PR TITLE
`start_neuron.sh` yes/no prompt is now skipped if variable is set + Added `FLASK_SERVER` miner-specific variables, related input parameter and skip for validators + Fixed `--use_bt_api` parameter and added skip when provided

### DIFF
--- a/scripts/start_neuron.sh
+++ b/scripts/start_neuron.sh
@@ -26,6 +26,7 @@ USE_BT_API=""
 # Miner-specific variables
 AXON_PORT=""
 VALIDATOR_MIN_STAKE=""
+FLASK_SERVER=""
 
 # Function to prompt for user input if not provided as an argument
 prompt_for_input() {
@@ -42,6 +43,13 @@ prompt_for_input() {
 prompt_yes_no() {
     local prompt="$1"
     local var_name="$2"
+    local current_value="${!var_name}"
+
+    # Skip prompt if var_name is already set to 'true' or 'false'
+    if [[ "$current_value" == "true" || "$current_value" == "false" ]]; then
+      return 0
+    fi
+
     while true; do
         read -p "$prompt [y/n]: " yn
         case $yn in
@@ -63,6 +71,7 @@ while [[ $# -gt 0 ]]; do
         --axon.port) AXON_PORT="$2"; shift 2 ;;
         --validator_min_stake) VALIDATOR_MIN_STAKE="$2"; shift 2 ;;
         --disable_auto_update) DISABLE_AUTO_UPDATE="$2"; shift 2 ;;
+        --start_flask_server) FLASK_SERVER="$2"; shift 2 ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
         --use_bt_api) USE_BT_API="--use_bt_api"; shift ;;
     esac
@@ -136,8 +145,11 @@ fi
 # Prompt for disabling auto-update if not provided
 prompt_yes_no "Do you want to disable auto-update? Warning: this will apply to all running neurons" "DISABLE_AUTO_UPDATE"
 
-# Prompt for starting Flask server
-prompt_yes_no "Would you like to start flask server for connecting to bettensor.com?" "FLASK_SERVER"
+# Prompt for starting flask server if not provided (only for miner)
+if [ "$NEURON_TYPE" = "miner" ]; then
+    # Prompt for starting Flask server
+    prompt_yes_no "Would you like to start flask server for connecting to bettensor.com?" "FLASK_SERVER"
+fi
 
 # Start the neuron with PM2
 if [ "$NEURON_TYPE" = "miner" ]; then

--- a/scripts/start_neuron.sh
+++ b/scripts/start_neuron.sh
@@ -28,6 +28,9 @@ AXON_PORT=""
 VALIDATOR_MIN_STAKE=""
 FLASK_SERVER=""
 
+# Vali-specific variables
+USE_BT_API_CHOICE=""
+
 # Function to prompt for user input if not provided as an argument
 prompt_for_input() {
     local prompt="$1"
@@ -72,8 +75,8 @@ while [[ $# -gt 0 ]]; do
         --validator_min_stake) VALIDATOR_MIN_STAKE="$2"; shift 2 ;;
         --disable_auto_update) DISABLE_AUTO_UPDATE="$2"; shift 2 ;;
         --start_flask_server) FLASK_SERVER="$2"; shift 2 ;;
+        --use_bt_api) USE_BT_API_CHOICE="$2"; shift 2 ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
-        --use_bt_api) USE_BT_API="--use_bt_api"; shift ;;
     esac
 done
 


### PR DESCRIPTION
In this pull request I added:

1. A check in the `prompt_yes_no()` function of the `start_neuron.sh` script to skip the prompt if the variable is already set to `true` or `false`
    - This allows users to fully automate the usage of the script by passing `--disable_auto_update` and/or `--start_flask_server`
2. The `FLASK_SERVER` miner-specific variable to go with the new `--start_flask_server` input parameter
3. Only prompting for the `FLASK_SERVER` when starting a miner neuron
4. Fixed error where passing `--use_bt_api` parameter would throw an `Unknown parameter passed` error
5. Replaced `--use_bt_api` assigned variable to `USE_BT_API_CHOICE` in order to properly set `USE_BT_API` value later in the script and skip the prompt if passed to the script

I tested by using it to setup a validator and with this testing script:
```
USE_BT_API=""

DISABLE_AUTO_UPDATE=""
FLASK_SERVER=""

USE_BT_API_CHOICE=""

prompt_yes_no() {
    local prompt="$1"
    local var_name="$2"
    local current_value="${!var_name}"

    # Check if var_name is already set to 'true' or 'false'
    if [[ "$current_value" == "true" || "$current_value" == "false" ]]; then
      echo "$var_name is already set to $current_value, skipping prompt."
      return 0
    fi

    while true; do
        read -p "$prompt [y/n]: " yn
        case $yn in
            [Yy]* ) eval $var_name="true"; break;;
            [Nn]* ) eval $var_name="false"; break;;
            * ) echo "Please answer yes or no.";;
        esac
    done
}

while [[ $# -gt 0 ]]; do
    case $1 in
        --neuron_type) NEURON_TYPE="$2"; shift 2 ;;
        --disable_auto_update) DISABLE_AUTO_UPDATE="$2"; shift 2 ;;
        --start_flask_server) FLASK_SERVER="$2"; shift 2 ;;
        --use_bt_api) USE_BT_API_CHOICE="$2"; shift 2 ;;
        *) echo "Unknown parameter passed: $1"; exit 1 ;;
    esac
done

# Prompt for disabling auto-update if not provided
prompt_yes_no "Do you want to disable auto-update? Warning: this will apply to all running neurons" "DISABLE_AUTO_UPDATE"

# Prompt for starting flask server if not provided (only for miner)
if [ "$NEURON_TYPE" = "miner" ]; then
    # Prompt for starting Flask server
    prompt_yes_no "Would you like to start flask server for connecting to bettensor.com?" "FLASK_SERVER"
fi

if [ "$NEURON_TYPE" = "validator" ]; then
    if [ -z "$USE_BT_API" ]; then
        prompt_yes_no "Do you want to use the BT API?" "USE_BT_API_CHOICE"
        if [ "$USE_BT_API_CHOICE" = "true" ]; then
            USE_BT_API="--use_bt_api"
        fi
    fi
fi

echo $DISABLE_AUTO_UPDATE
echo $FLASK_SERVER
echo $USE_BT_API
```

Test outputs:
![image](https://github.com/user-attachments/assets/934b432d-9f51-429a-9d30-cfaab36eb645)
